### PR TITLE
Add multiple battery support for linux

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -2,14 +2,14 @@
   (:nicknames #:trivial-battery/main)
   #+linux
   (:import-from #:trivial-battery/os/linux
-                #:battery-info)
+                #:battery-info #:battery-details)
   #+darwin
   (:import-from #:trivial-battery/os/mac
-                #:battery-info)
+                #:battery-info #:battery-details)
   #+(or win32 windows)
   (:import-from #:trivial-battery/os/windows
-                #:battery-info)
-  (:export #:battery-info))
+                #:battery-info #:battery-details)
+  (:export #:battery-info #:battery-details))
 
 #-(or linux darwin win32 windows)
 (error "Unsupported operating system.")

--- a/os/mac.lisp
+++ b/os/mac.lisp
@@ -38,11 +38,15 @@
 
 (defun battery-info ()
   (let ((info (parse-xml (get-response-xml))))
-    `(("percentage". ,(if (cdr (assoc "FullyCharged" info :test #'string=))
-                          100
-                          (floor
-                           (* (/ (cdr (assoc "CurrentCapacity" info :test #'string=))
-                                 (cdr (assoc "MaxCapacity" info :test #'string=)))
-                              100))))
-      ("charging" . ,(or (cdr (assoc "FullyCharged" info :test #'string=))
-                         (cdr (assoc "IsCharging" info :test #'string=)))))))
+    `((("percentage". ,(if (cdr (assoc "FullyCharged" info :test #'string=))
+                           100
+                           (floor
+                            (* (/ (cdr (assoc "CurrentCapacity" info :test #'string=))
+                                  (cdr (assoc "MaxCapacity" info :test #'string=)))
+                               100))))
+       ("charging" . ,(or (cdr (assoc "FullyCharged" info :test #'string=))
+                          (cdr (assoc "IsCharging" info :test #'string=))))))))
+
+(defun battery-details (battery)
+  (declare (ignore battery))
+  (first (battery-info)))

--- a/os/windows.lisp
+++ b/os/windows.lisp
@@ -50,5 +50,9 @@
   (not (eql (parse-response (get-wmic-battery-status)) 1)))
 
 (defun battery-info ()
-  `(("percentage" . ,(battery-percentage))
-    ("charging" . ,(battery-charging-p))))
+  `((("percentage" . ,(battery-percentage))
+     ("charging" . ,(battery-charging-p)))))
+
+(defun battery-details (battery)
+  (declare (ignore battery))
+  (first (battery-info)))


### PR DESCRIPTION
- battery-info now returns a list of batteries
- add battery-details which returns additional detail about a single battery
- minor cleanup in file reading functions
- add some minor utility in linux implementation
- add trivial equivalents in windows and OS X implementations (I only have Linux machines, so I can't test the others :/ )